### PR TITLE
Add fix to include putting flags even after filenames in any order

### DIFF
--- a/include/concat.h
+++ b/include/concat.h
@@ -28,7 +28,7 @@ void flush_out_buff(size_t *out_index, size_t len, FORCE_FLUSH);
 #define LINE_NO_SIZE 16     //24, for 64 bit implementation 
 
 //handle concatenation when default input is stdin
-void stdin_concat(void);
+void stdin_concat(TOKEN_T tok);
 
 // Ctrl + C(interrupt) or Ctrl + D (EOF) signal handler
 void interrupt_handler(int);
@@ -36,7 +36,7 @@ void interrupt_handler(int);
 //Parse filenames and print the content on the screen
 void parse_files(TOKEN_T, const char*);
 
-//write file content to stdout and modify according to flags
-void print_file(TOKEN_T, char[BUFF_LENGTH], size_t);
+//write buffer content to stdout and modify according to flags
+void print_buffer(TOKEN_T, char[BUFF_LENGTH], size_t);
 
 #endif

--- a/src/concat.c
+++ b/src/concat.c
@@ -7,29 +7,23 @@
 #include "../include/concat.h"
 #include "../include/parse_token.h"
 
-void stdin_concat(void)
+void stdin_concat(TOKEN_T tok)
 {
     while (1)
     {
-        char *ptr;
-        ptr = fgets(buff, BUFF_LENGTH, stdin);
-        if (ptr == NULL)
+        ssize_t bytes;
+        bytes = read(STDIN_FILENO, buff, BUFF_LENGTH);
+        if (bytes == -1)
         {
-            if (feof(stdin))
-            {
-                exit(EXIT_SUCCESS);
-            }
-            if (ferror(stdin))
-            {
-                perror("can't read from stdin");
-                exit(EXIT_FAILURE);
-            }
-        }
-        if (!(fputs(buff, stdout) > 0))
-        {
-            perror("can't write to stdout");
+            perror("can't read from stdin");
             exit(EXIT_FAILURE);
         }
+        else if (bytes == 0)
+        {
+            exit(EXIT_SUCCESS);
+        }
+        print_buffer(tok, buff, bytes);
+        flush_out_buff(&out_buff_index, 0, 1);
     }
 };
 
@@ -51,7 +45,7 @@ void parse_files(TOKEN_T tok, const char *fname)
         }
         else
         {
-            print_file(tok, buff, bytes);
+            print_buffer(tok, buff, bytes);
         }
     }
     if (bytes == -1)
@@ -66,7 +60,7 @@ void parse_files(TOKEN_T tok, const char *fname)
     }
 };
 
-void print_file(TOKEN_T tok, char buff[BUFF_LENGTH], size_t bytes)
+void print_buffer(TOKEN_T tok, char buff[BUFF_LENGTH], size_t bytes)
 {
     static int line_no = 1;
     static char last_char = '\n';

--- a/src/my_cat.c
+++ b/src/my_cat.c
@@ -20,7 +20,7 @@ int main(int argc, char ** argv)
     signal(SIGINT, interrupt_handler);
     if (argc == 1)
     {
-        stdin_concat();
+        stdin_concat(flag_tokens);
     }
     else if (argc == 2 && !strncmp(argv[1], "--help", strlen("--help")))
     {
@@ -36,20 +36,32 @@ int main(int argc, char ** argv)
     }
     else
     {
-        int i = 1;
-        while (i < argc && !strncmp(argv[i], "-", 1))
+        int flag_count = 0;
+        for (int i = 1; i < argc; i++)
         {
-            parse_token(&flag_tokens, argv[i]);
-            i++;
+            if ( argv[i][0] == '-' )
+            {
+                parse_token(&flag_tokens, argv[i]);
+                flag_count ++;
+            }
+            else if ( argv[i][0] == '<' || argv[i][0] == '>' )
+            {
+                flag_count++;
+            }
         }
-        if (i == argc)
+        if (flag_count == argc -1)
         {
-            fprintf(stderr, "missing FILENAME argument\n");
-            exit(EXIT_SUCCESS);
+            stdin_concat(flag_tokens);
+            flush_out_buff(&out_buff_index, 0, FORCE_T);
+            return 0;
         }
-        for (; i < argc; i++)
+
+        for (size_t i = 1; i < argc; i++)
         {
-            parse_files(flag_tokens, argv[i]);
+            if (argv[i][0] != '-' && argv[i][0] != '<' && argv[i][0] != '>')
+            {
+                parse_files(flag_tokens, argv[i]);
+            }
         }
         flush_out_buff(&out_buff_index, 0, FORCE_T);
     }


### PR DESCRIPTION
```
./build/my_cat test.txt -n     // now, we can add flags after adding filenames without following any order
```